### PR TITLE
Including kernel headers to build/use DKMS modules when booted to live

### DIFF
--- a/lxqt/Packages-Live
+++ b/lxqt/Packages-Live
@@ -20,5 +20,4 @@ xf86-video-sisusb
 xf86-video-vesa
 xf86-video-vmware
 xf86-video-voodoo
-arch-install-scripts
 linux-lts-headers

--- a/lxqt/Packages-Live
+++ b/lxqt/Packages-Live
@@ -20,3 +20,5 @@ xf86-video-sisusb
 xf86-video-vesa
 xf86-video-vmware
 xf86-video-voodoo
+arch-install-scripts
+linux-lts-headers


### PR DESCRIPTION
Since base was removed, I would like to add the kernel headers to the lqxt live CD, (I'll add them to the others, too, if requested.)

Also including arch-install-scripts to give more fine grained installs beyond Calamares' capabilities.

