### PR TITLE
remove lxqt-common and add lxqt-themes

### DIFF
--- a/lxqt/Packages-Desktop
+++ b/lxqt/Packages-Desktop
@@ -14,7 +14,6 @@ inxi
 kwrite
 lxqt-about
 lxqt-admin
-lxqt-common
 lxqt-config
 lxqt-globalkeys
 lxqt-notificationd
@@ -26,6 +25,7 @@ lxqt-qtplugin
 lxqt-runner
 lxqt-session
 lxqt-sudo
+lxqt-themes
 media-player-info
 mobile-broadband-provider-info
 modemmanager


### PR DESCRIPTION
As lxqt version 0.12.0 has been released :

http://lxqt.org/release/2017/10/21/lxqt-0120/

The lxqt team has dropped lxqt-common and introduces lxqt-themes component.
This causes arch folks to followsuit by removing lxqt-common completely in repo and replace it with lxqt-theme as evidenced in these commits :

https://git.archlinux.org/svntogit/community.git/commit/?id=ba85fc1aff9d9c67dd0a71a77ef8b62f03f4412c
https://git.archlinux.org/svntogit/community.git/commit/?id=afd81aad2bcf45e76bd08a1e9c2631c8720282b9

Because of this changes. It causes users reported that calamares has failed its installation because it couldn't find lxqt-common anymore (as it was been removed in the repo)

https://artixlinux.org/forum/index.php?topic=155.msg1311#msg1311

A simple remove of the line lxqt-common and replace it with lxqt-theme in lxqt/Packages-Destkop should fix this issue

(This is the place where calamares sources its package selection menu right?)

Signed-off-by: Rafli Akmal <rafliakmaltejakusuma@gmail.com>