### PR TITLE
Removing pcmcia-utils

### DIFF
--- a/base/Packages-Root
+++ b/base/Packages-Root
@@ -72,7 +72,6 @@ artix-sysvcompat
 os-prober
 pacman
 pciutils
-pcmciautils
 perl
 procps-ng
 psmisc


### PR DESCRIPTION
This package was removed from Archlinux in june 2018.

See this mail : https://lists.archlinux.org/pipermail/arch-dev-public/2018-June/029270.html